### PR TITLE
#17: add color prefix to globals css variables

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,91 +1,44 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-
-  /* Primitive color variables */
-  --neutral-white: #ffffff;
-  --neutral-lightest: #f2f2f2;
-  --neutral-lighter: #d8d8d8;
-  --neutral-light: #b2b2b2;
-  --neutral: #7f7f7f;
-  --neutral-dark: #4c4c4c;
-  --neutral-darker: #191919;
-  --neutral-darkest: #000000;
-
-  --capecod-lightest: #ebecec;
-  --capecod-lighter: #d7dad9;
-  --capecod-light: #757e7c;
-  --capecod: #3a4744;
-  --capecod-dark: #2e3836;
-  --capecod-darker: #171c1b;
-  --capecod-darkest: #111514;
-
-  /* Semantic color variables */
-  --color-text-primary: var(--neutral-darker);
-  --color-text-secondary: var(--neutral-dark);
-  --color-text-inverse: var(--neutral-white);
-  --color-background-primary: var(--neutral-lightest);
-  --color-background-inverse: var(--neutral-darker);
-  --color-border: var(--neutral-lighter);
-  --color-border-strong: #19191926; /* neutral-darker with 15% opacity */
-  --color-accent: var(--capecod);
-  --color-accent-light: var(--capecod-lightest);
-  --color-accent-dark: var(--capecod-dark);
-
-  --font-merriweather: var(--font-merriweather);
-  --font-pt-sans: var(--font-pt-sans);
-}
-
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
+  --color-background: #ffffff;
+  --color-foreground: #171717;
+
+  /* Color variables */
+  --color-neutral-white: #ffffff;
+  --color-neutral-lightest: #f2f2f2;
+  --color-neutral-lighter: #d8d8d8;
+  --color-neutral-light: #b2b2b2;
+  --color-neutral: #7f7f7f;
+  --color-neutral-dark: #4c4c4c;
+  --color-neutral-darker: #191919;
+  --color-neutral-darkest: #000000;
+
+  --color-capecod-lightest: #ebecec;
+  --color-capecod-lighter: #d7dad9;
+  --color-capecod-light: #757e7c;
+  --color-capecod: #3a4744;
+  --color-capecod-dark: #2e3836;
+  --color-capecod-darker: #171c1b;
+  --color-capecod-darkest: #111514;
+
+  /* Font variables */
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-
-  /* Inline custom color variables for Tailwind v4 */
-  --neutral-white: #ffffff;
-  --neutral-lightest: #f2f2f2;
-  --neutral-lighter: #d8d8d8;
-  --neutral-light: #b2b2b2;
-  --neutral: #7f7f7f;
-  --neutral-dark: #4c4c4c;
-  --neutral-darker: #191919;
-  --neutral-darkest: #000000;
-
-  --capecod-lightest: #ebecec;
-  --capecod-lighter: #d7dad9;
-  --capecod-light: #757e7c;
-  --capecod: #3a4744;
-  --capecod-dark: #2e3836;
-  --capecod-darker: #171c1b;
-  --capecod-darkest: #111514;
-
-  --color-text-primary: var(--neutral-darker);
-  --color-text-inverse: var(--neutral-white);
-  --color-background-primary: var(--neutral-lightest);
-  --color-background-inverse: var(--neutral-darker);
-  --color-border: var(--neutral-lighter);
-  --color-border-strong: #19191926;
-  --color-accent: var(--capecod);
-  --color-accent-light: var(--capecod-lightest);
-  --color-accent-dark: var(--capecod-dark);
-
   --font-merriweather: var(--font-merriweather);
   --font-pt-sans: var(--font-pt-sans);
   --font-poppins: var(--font-poppins);
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+  @theme inline {
+    --color-background: #0a0a0a;
+    --color-foreground: #ededed;
   }
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
+  background: var(--color-background);
+  color: var(--color-foreground);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -91,7 +91,7 @@ export default function Navbar() {
 
       {/* Mobile dropdown nav */}
       <nav
-        className={`absolute top-full right-0 left-0 z-50 flex flex-col bg-capecod pb-8 text-[var(--color-text-inverse)] shadow-lg transition-all duration-300 ease-in-out sm:hidden ${
+        className={`absolute top-full right-0 left-0 z-50 flex flex-col bg-capecod pb-8 shadow-lg transition-all duration-300 ease-in-out sm:hidden ${
           open ? "visible translate-y-0 opacity-100" : "invisible -translate-y-4 opacity-0"
         }`}
         aria-label="Mobile navigation"

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -29,7 +29,7 @@ export default function Navbar() {
   return (
     <header
       className={`sticky top-0 z-50 w-full transition-all duration-300 ${
-        isScrolled ? "bg-[var(--capecod)] shadow-md" : "bg-[var(--capecod)]"
+        isScrolled ? "bg-capecod shadow-md" : "bg-capecod"
       }`}
     >
       {/* Navigation bar */}
@@ -76,7 +76,7 @@ export default function Navbar() {
         </button>
 
         {/* Desktop nav */}
-        <nav className="ml-8 hidden gap-8 sm:flex">
+        {/* <nav className="ml-8 hidden gap-8 sm:flex">
           {navLinks.map((link) => (
             <a
               key={link.label}
@@ -86,12 +86,12 @@ export default function Navbar() {
               {link.label}
             </a>
           ))}
-        </nav>
+        </nav> */}
       </div>
 
       {/* Mobile dropdown nav */}
       <nav
-        className={`absolute top-full right-0 left-0 z-50 flex flex-col bg-[var(--capecod)] pb-8 text-[var(--color-text-inverse)] shadow-lg transition-all duration-300 ease-in-out sm:hidden ${
+        className={`absolute top-full right-0 left-0 z-50 flex flex-col bg-capecod pb-8 text-[var(--color-text-inverse)] shadow-lg transition-all duration-300 ease-in-out sm:hidden ${
           open ? "visible translate-y-0 opacity-100" : "invisible -translate-y-4 opacity-0"
         }`}
         aria-label="Mobile navigation"
@@ -109,7 +109,7 @@ export default function Navbar() {
             >
               <a
                 href={link.href}
-                className="text-base font-[var(--font-pt-sans)] text-[var(--color-text-inverse)] hover:underline"
+                className="font-pt-sans text-base hover:underline"
                 onClick={() => setOpen(false)}
               >
                 {link.label}

--- a/src/components/home-sections/hero.tsx
+++ b/src/components/home-sections/hero.tsx
@@ -6,7 +6,7 @@ import FadeInWrapper from "components/shared/FadeInWrapper";
 
 export default function Hero() {
   return (
-    <section className="w-full bg-[var(--capecod)] text-white">
+    <section className="w-full bg-capecod text-white">
       <div className="px-6 py-16">
         <div className="mx-auto max-w-4xl space-y-6 text-left">
           <FadeInWrapper delay={0} as="h1" className="font-merriweather text-4xl font-bold">

--- a/src/components/home-sections/programs.tsx
+++ b/src/components/home-sections/programs.tsx
@@ -23,7 +23,7 @@ export default function Programs() {
   ];
 
   return (
-    <section className="bg-[var(--neutral-lightest)] px-6 py-16 text-gray-950">
+    <section className="bg-neutral-lightest px-6 py-16 text-gray-950">
       <FadeInWrapper delay={0}>
         <HeadingWithTag heading="Programs and Services" tag="Services" />
       </FadeInWrapper>
@@ -54,11 +54,7 @@ export default function Programs() {
       ))}
 
       <FadeInWrapper delay={200}>
-        <LinkButton
-          href="/services"
-          variant="filled"
-          className="mt-6 bg-[var(--neutral-darkest)]/10"
-        >
+        <LinkButton href="/services" variant="filled" className="mt-6 bg-neutral-darkest/10">
           Learn More
         </LinkButton>
       </FadeInWrapper>

--- a/src/components/home-sections/upcoming.tsx
+++ b/src/components/home-sections/upcoming.tsx
@@ -32,7 +32,7 @@ const events = [
 
 export default function Upcoming() {
   return (
-    <section className="flex w-full flex-col items-center bg-[var(--capecod-lighter)] px-6 py-16 text-gray-950">
+    <section className="flex w-full flex-col items-center bg-capecod-lighter px-6 py-16 text-gray-950">
       <FadeInWrapper className="text-center">
         <HeadingWithTag heading="Events" tag="Upcoming" />
         <p>Join us for these upcoming events organised by our community</p>
@@ -57,7 +57,7 @@ export default function Upcoming() {
 
       <div className="mt-12 flex justify-center">
         <FadeInWrapper>
-          <LinkButton href="/upcoming" variant="filled" className="bg-[var(--neutral-darkest)]/10">
+          <LinkButton href="/upcoming" variant="filled" className="bg-neutral-darkest/10">
             View All
           </LinkButton>
         </FadeInWrapper>

--- a/src/components/home-sections/updates.tsx
+++ b/src/components/home-sections/updates.tsx
@@ -28,7 +28,7 @@ export default function Updates() {
   ];
 
   return (
-    <section className="flex w-full flex-col items-center bg-[var(--capecod-lighter)] px-6 py-16 text-gray-950">
+    <section className="flex w-full flex-col items-center bg-capecod-lighter px-6 py-16 text-gray-950">
       <FadeInWrapper className="text-center">
         <HeadingWithTag heading="Latest News and Updates" tag="Updates" />
         <p>Stay informed about our community events</p>
@@ -50,7 +50,7 @@ export default function Updates() {
 
       <div className="mt-2 flex justify-center">
         <FadeInWrapper>
-          <LinkButton href="/updates" variant="filled" className="bg-[var(--neutral-darkest)]/10">
+          <LinkButton href="/updates" variant="filled" className="bg-neutral-darkest/10">
             View All
           </LinkButton>
         </FadeInWrapper>

--- a/src/components/shared/EventCard.tsx
+++ b/src/components/shared/EventCard.tsx
@@ -32,7 +32,7 @@ export default function EventCard({
 
   if (isUpcoming) {
     return (
-      <div className="flex flex-col overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--capecod-lightest)]">
+      <div className="flex flex-col overflow-hidden rounded-xl bg-capecod-lightest">
         <CroppedImage
           src={image}
           alt={title}

--- a/src/components/shared/LinkButton.tsx
+++ b/src/components/shared/LinkButton.tsx
@@ -18,11 +18,9 @@ export default function LinkButton({
     "rounded-md px-4 font-semibold py-2 transition-colors font-pt-sans inline-block";
 
   const variantStyles = {
-    filled: "bg-white text-[var(--capecod)] hover:bg-gray-100",
-    outlined:
-      "border-2 border-white bg-transparent text-white hover:bg-white hover:text-[var(--capecod)]",
-    elevated:
-      "bg-white text-[var(--capecod)] hover:bg-gray-100 shadow-md border-b-4 border-gray-800/30",
+    filled: "bg-white text-capecod hover:bg-gray-100",
+    outlined: "border-2 border-white bg-transparent text-white hover:bg-white hover:text-capecod",
+    elevated: "bg-white text-capecod hover:bg-gray-100 shadow-md border-b-4 border-gray-800/30",
   };
 
   const mergedClassName = twMerge(baseStyles, variantStyles[variant], className);


### PR DESCRIPTION
- Tailwind v4 uses globals.css for custom theme variables
- these variables need to be prefixed with `color` or `font` depending on the type of variable
- this way they can be used in tailwind className directly like this: `bg-capecod` instead of `bg-[var(--capecod)]`